### PR TITLE
Fixes #45 - Additional defensive code

### DIFF
--- a/celi_framework/core/processor.py
+++ b/celi_framework/core/processor.py
@@ -204,8 +204,17 @@ class ProcessRunner:
         )
 
         if self.pop_context_flag:
-            self.update_draft_doc(self.ongoing_chat)
-            self.handle_pop_context()
+            try:
+                self.update_draft_doc(self.ongoing_chat)
+            except Exception as e:
+                app_logger.exception(
+                    f"Error updating draft doc, retrying", extra={"color": "red"}
+                )
+                self.pop_context_flag = False
+
+            if self.pop_context_flag:
+                self.handle_pop_context()
+
 
     def format_chat_messages(self, msgs: List[ChatMessageable]):
         return "\n\n".join(self.format_message_content(m) for m in msgs)

--- a/celi_framework/utils/llmcore_utils.py
+++ b/celi_framework/utils/llmcore_utils.py
@@ -203,7 +203,12 @@ def parse(dataclass_parser: ParserFactory, target_cls: Type[T], msg: str) -> T:
     """
     try:
         with dataclass_parser(target_cls) as parser:
-            ret = parser.parse(msg)  # type: ignore
+            try:
+                ret = parser.parse(msg)  # type: ignore
+            except Exception:
+                app_logger.info(f"Parsing failed, retrying")
+                msg = "Make sure your response is valid JSON.\n"+ msg
+                ret = parser.parse(msg)  # type: ignore
             app_logger.info(f"Parsed {ret}")
             setattr(ret, "parser_model", parser.model_name)
             return ret


### PR DESCRIPTION
The current dataclass parser assumed the LLM will return valid JSON.  We now handle this by first retrying with a modified prompt and then just continuing the dialog if it fails on retry.