### PR TITLE
Change writing of output to be part of ToolImplementations

### DIFF
--- a/celi_framework/core/runner.py
+++ b/celi_framework/core/runner.py
@@ -16,14 +16,12 @@ from celi_framework.utils.log import app_logger
 @dataclass
 class Directories:
     output_dir: str
-    drafts_dir: str
     evaluations_dir: str
 
     @staticmethod
     def create(output_dir: str) -> Directories:
         return Directories(
             output_dir=output_dir,
-            drafts_dir=f"{output_dir}/drafts",
             evaluations_dir=f"{output_dir}/evaluations",
         )
 
@@ -69,7 +67,6 @@ def run_celi(celi_config: CELIConfig):
         codex=codex,
         parser_factory=parser_factory,
         tool_implementations=celi_config.tool_implementations,
-        drafts_dir=celi_config.directories.drafts_dir,
         llm_cache=celi_config.llm_cache,
     )
 
@@ -96,4 +93,4 @@ def run_celi(celi_config: CELIConfig):
     # Wait for threads to finish
     [_.join() for _ in threads]
     app_logger.info("Threads completed. Exiting.")
-    return process_runner.draft_doc
+    return

--- a/celi_framework/examples/reporting_template/tools.py
+++ b/celi_framework/examples/reporting_template/tools.py
@@ -16,7 +16,7 @@ from typing import Dict
 from attr import dataclass
 from celi_framework.core.job_description import (
     ToolImplementations,
-    generate_tool_descriptions,
+    generate_tool_descriptions, BaseDocToolImplementations,
 )
 from celi_framework.core.templates import (
     make_draft_setting_output_prompt,
@@ -38,7 +38,7 @@ class Document:
     content: Dict[str, str]
 
 
-class ReportingToolImplementations(ToolImplementations):
+class ReportingToolImplementations(BaseDocToolImplementations):
     doc_dir: str
 
     def __init__(self, doc_dir: str):

--- a/celi_framework/examples/wikipedia/job_description.py
+++ b/celi_framework/examples/wikipedia/job_description.py
@@ -49,6 +49,8 @@ task_library = [
             "description": """Determine if any additional information is required to draft the section and call the ask_question_about_target function to gather that information.
             Feel free to ask as many questions as you need and keep working on this task until you have the information you need.  This is especially important if
             the initial references turn out not to be useful.
+            If you ask questions, make sure they are specific and include the names of what you are asking about.  For 
+            example, ask "What are major events in Henry Thoreau's life" instead of "What are major events in the author's life?"
             If you don't have any questions, just move on to the next section.""",
             "example_call": '{"prompt": "What is unusual about when this band formed?"}',
         },
@@ -63,7 +65,11 @@ task_library = [
     Task(
         task_name="Draft New Document Section",
         details={
-            "description": "Draft a new section analogous to the revised example section, ensuring alignment with its structure, format, and scope (from {{TaskRef:Understand Differentiation}} output).  Use the section structure you defined in {{TaskRef:Define subsections for this section}}. However, the details should be related to the target and not the example document.",
+            "description": "Draft a new section analogous to the revised example section, ensuring alignment with its "
+                           "structure, format, and scope (from {{TaskRef:Understand Differentiation}} output).  Use "
+                           "the section structure you defined in {{TaskRef:Define subsections for this section}}. "
+                           "However, the details should be related to the target and not the example document."
+                           "Call the save_draft_section tool to save the draft.",
             "guidelines": [
                 "Clearly identify the section number and section heading/title at the top of the content.",
                 "The new section should have its unique scope and purpose, distinct from the example section.",
@@ -79,55 +85,16 @@ task_library = [
             ],
         },
     ),
-    # Task(
-    #     task_name="Final Section Review",
-    #     details={
-    #         "description": "Review the final text for this section and provide a PASS/FAIL decision based on the success criteria.",
-    #         "prerequisite_tasks": ["Draft New Document Section"],
-    #         "instructions": [
-    #             "Evaluate the success of the new section draft",
-    #             "Document the review outcome",
-    #             "Print the final review output.",
-    #         ],
-    #         "success_flag_criteria": {
-    #             "FAIL": [
-    #                 "The section includes information beyond what's relevant as indicated by {{TaskRef:Understand Differentiation}}.",
-    #                 "Any mention of specific drugs or combination therapies not relevant to the new study context.",
-    #                 "Information in the new section is redundant with the sections analyzed in {{TaskRef:Understand Differentiation}}.",
-    #                 "The draft does not reflect the structure, format, or detail level of the revised example section (output of {{TaskRef:Handle Treatment Details}}).",
-    #                 "Missing or incorrectly referenced tables or figures from the new reference materials.",
-    #                 "Significant deviation from the new reference materials, suggesting misalignment with the study's current focus.",
-    #                 "Inconsistent use of verb tenses where required.",
-    #             ],
-    #             "PASS": [
-    #                 "The section appropriately includes information within the scope defined by {{TaskRef:Understand Differentiation}}.",
-    #                 "The draft logically follows what the section heading describes.",
-    #                 "The draft focuses exclusively on the new study context.",
-    #                 "The draft meets criteria for completeness, accuracy, and is aligned with the revised example and the new reference materials.",
-    #             ],
-    #         },
-    #         "additional_instructions": "Offer feedback on the process of differentiating from other sections, the use of source materials, and the rationale for selected source mappings.",
-    #         "output_format": {
-    #             "Section Review": "[SECTION NUMBER] - [SECTION HEADING]",
-    #             "Draft Review": "[content here]",
-    #             "Comments": "[comments here]",
-    #             "Success Flag": "[FAIL/PASS]",
-    #             "Source Mapping Review": "[REVIEW OF UTILIZED SOURCES]",
-    #             "Tables": "[LIST OF REFERENCED TABLES]",
-    #             "Figures": "[LIST OF REFERENCED FIGURES]",
-    #             "Cross-References": "[REFERENCES TO OTHER DOCUMENT SECTIONS (FROM EXAMPLE DOCUMENT)]",
-    #             "Scope of Section Review": "[REFLECTION ON FOLLOWING THE SCOPE GUIDELINES SET OUT IN {{TaskRef:Understand Differentiation}} OUTPUT]",
-    #         },
-    #     },
-    # ),
     Task(
         task_name="Prepare for Next Document Section",
         details={
-            "description": "SIgnal that you have completed the draft by calling the pop_context function and prepare to start drafting the next section of the document.",
+            "description": "Signal that you have completed the draft by calling the pop_context function and prepare "
+                           "to start drafting the next section of the document.",
             "function_call": "Use the pop_context function with the argument value = current section identifier.",
             "example_call": "{{'current_section_identifier': ['1.2']}}",
             "instructions": [
-                "Announce completion: 'Proceed to the next section of the document, [current section identifier] has been completed.'"
+                "Announce completion: 'Proceed to the next section of the document, [current section identifier] has "
+                "been completed.'"
             ],
         },
     ),

--- a/celi_framework/examples/wikipedia/loader.py
+++ b/celi_framework/examples/wikipedia/loader.py
@@ -9,6 +9,7 @@ __all__ = [
     "ContentHierarchyNode",
     "ContentReference",
     "load_content_from_wikipedia_url",
+    "format_content",
 ]
 
 


### PR DESCRIPTION
Moved writing of the output to the tools instead of being in the core processor.

UPGRADE NOTE:
ToolImplementations should inherit from BaseDocToolImplementations instead of ToolImplementations.  This version now has a `save_draft_section` function that is used to write the output.  This is no longer done as part of the processor.