### PR TITLE
Fixes #74 Don't search all history for duplicates.

### DIFF
--- a/celi_framework/core/section_processor.py
+++ b/celi_framework/core/section_processor.py
@@ -155,10 +155,10 @@ class SectionProcessor:
             return False
         last_message = ongoing_chat[-1]
         duplicates = 0
-        for message in ongoing_chat[:-1]:
+        for message in ongoing_chat[-7:-1]:
             if message == last_message:
                 duplicates += 1
-        return duplicates > 2
+        return duplicates >= 3
 
     async def builtin_review(self):
         task_specific = (


### PR DESCRIPTION
Since sometimes there is a loop that alternates between 2 prompts, I changed duplicate detection to look for 3 duplicates in the last 6 messages.