### PR TITLE
Added --token-budget option

### DIFF
--- a/celi_framework/core/runner.py
+++ b/celi_framework/core/runner.py
@@ -9,6 +9,7 @@ from celi_framework.core.mt_factory import MasterTemplateFactory
 from celi_framework.core.processor import ProcessRunner
 from celi_framework.utils.llm_cache import enable_llm_caching, get_celi_llm_cache
 from celi_framework.utils.log import app_logger
+from celi_framework.utils.token_counters import TokenCounter
 
 
 @dataclass
@@ -20,6 +21,7 @@ class CELIConfig:
     max_tokens: int
     model_url: Optional[str]
     simulate_live: bool = False
+    token_budget: int = 0
 
 
 def run_celi(celi_config: CELIConfig):
@@ -58,6 +60,7 @@ async def run_process_runner(celi_config):
             primary_model_name=celi_config.primary_model_name,
             model_url=celi_config.model_url,
             max_tokens=celi_config.max_tokens,
+            token_counter=TokenCounter(celi_config.token_budget),
         )
 
         if celi_config.llm_cache:

--- a/celi_framework/core/section_processor.py
+++ b/celi_framework/core/section_processor.py
@@ -10,6 +10,7 @@ from celi_framework.core.celi_update_callback import CELIUpdateCallback
 from celi_framework.core.job_description import ToolImplementations
 from celi_framework.utils.llms import ToolDescription, ask_split
 from celi_framework.utils.log import app_logger
+from celi_framework.utils.token_counters import TokenCounter
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ class SectionProcessor:
     max_tokens: int
     callback: Optional[CELIUpdateCallback] = None
     model_url: Optional[str] = None
+    token_counter: Optional[TokenCounter] = None
 
     def __post_init__(self):
         self.ongoing_chat: List[Dict[str, str] | Tuple[str, str]] = []
@@ -103,6 +105,7 @@ class SectionProcessor:
             tool_descriptions=self.tool_descriptions,
             model_url=self.model_url,
             max_tokens=self.max_tokens,
+            token_counter=self.token_counter,
         )
         self._update_ongoing_chat(
             ("assistant", str(llm_response.message.content or ""))
@@ -194,6 +197,7 @@ class SectionProcessor:
             json_mode=True,
             model_url=self.model_url,
             max_tokens=self.max_tokens,
+            token_counter=self.token_counter,
         )
         text_response = llm_response.message.content.strip()
 

--- a/celi_framework/examples/AP_English_Language/run_gpt_alone.py
+++ b/celi_framework/examples/AP_English_Language/run_gpt_alone.py
@@ -36,6 +36,6 @@ for i in range(1, 4):
         whole_prompt = f"{system_message}\n\n{user_prompt}"
 
         # print(f"{whole_prompt}\n\n")
-        llm_response = quick_ask(prompt=whole_prompt, token_counter=None)
+        llm_response = quick_ask(prompt=whole_prompt)
 
         print(llm_response)

--- a/celi_framework/examples/GRE/run_gpt_alone.py
+++ b/celi_framework/examples/GRE/run_gpt_alone.py
@@ -50,9 +50,7 @@ def run_gpt():
         print(f"{whole_prompt}")
 
         # print(f"{whole_prompt}\n\n")
-        llm_response = quick_ask(
-            prompt=whole_prompt, token_counter=None, model_name="gpt-4o"
-        )
+        llm_response = quick_ask(prompt=whole_prompt, model_name="gpt-4o")
 
         # save gpt_outputs
         print("successfully created gpt output for question " + key)
@@ -77,7 +75,7 @@ def run_gpt():
         print(f"{whole_prompt}")
 
         # print(f"{whole_prompt}\n\n")
-        llm_response = quick_ask(prompt=whole_prompt, token_counter=None)
+        llm_response = quick_ask(prompt=whole_prompt)
 
         # Specify the directory and filename
         file_path = f"output/gpt/{key}_final_essay_gpt_scored.docx"

--- a/celi_framework/examples/reporting_template/tools.py
+++ b/celi_framework/examples/reporting_template/tools.py
@@ -24,7 +24,6 @@ from celi_framework.experimental.templates import (
 )
 from celi_framework.utils.llms import quick_ask
 from celi_framework.utils.log import app_logger
-from celi_framework.utils.token_counters import get_master_counter_instance
 from celi_framework.utils.utils import (
     format_toc,
     get_section_context_as_text,
@@ -194,7 +193,6 @@ class ReportingToolImplementations(BaseDocToolImplementations):
         # Send the prompt to an external service (LLM)
         response_str = quick_ask(
             prompt,
-            token_counter=get_master_counter_instance(),
             json_output=True,
             timeout=150,
             model_name="gpt-4-0125-preview",
@@ -235,7 +233,6 @@ class ReportingToolImplementations(BaseDocToolImplementations):
         # Send the prompt to an external service (LLM)
         response_str = quick_ask(
             prompt,
-            token_counter=get_master_counter_instance(),
             json_output=True,
             model_name="gpt-4-0125-preview",
         )

--- a/celi_framework/experimental/monitor.py
+++ b/celi_framework/experimental/monitor.py
@@ -227,9 +227,7 @@ class MonitoringAgent:
                 model_name = "gpt-4-32k"
             else:
                 model_name = "gpt-4-0125-preview"
-            response = quick_ask(
-                prompt, token_counter=self.token_counter, model_name=model_name
-            )
+            response = quick_ask(prompt, model_name=model_name)
         except ContextLengthExceededException as e:
             app_logger.info(
                 f"Context length issue with model {model_name}: {e}",
@@ -241,9 +239,7 @@ class MonitoringAgent:
                 app_logger.info(
                     f"Trying {model_name} instead: {e}", extra={"color": "orange"}
                 )
-                response = quick_ask(
-                    prompt, token_counter=self.token_counter, model_name=model_name
-                )
+                response = quick_ask(prompt, model_name=model_name)
             except ContextLengthExceededException as e:
                 app_logger.error(
                     f"Failed again with model {model_name}: {e}", extra={"color": "red"}

--- a/celi_framework/experimental/preprocessing/word_pdf_extractors/pdf_extractor.py
+++ b/celi_framework/experimental/preprocessing/word_pdf_extractors/pdf_extractor.py
@@ -30,7 +30,6 @@ import regex
 
 from celi_framework.experimental.templates import make_toc_prompt
 from celi_framework.utils.llms import quick_ask
-from celi_framework.utils.token_counters import get_master_counter_instance
 from .extractor_helpers import save_to_json, toc_iterator
 
 pd.set_option("display.max_colwidth", 0)
@@ -50,7 +49,6 @@ def create_toc(doc):
     response = quick_ask(
         prompt,
         json_output=True,
-        token_counter=get_master_counter_instance(),
         model_name="gpt-4-0125-preview",
     )
     toc_dict = json.loads(response)

--- a/celi_framework/experimental/utils/mapper_utils.py
+++ b/celi_framework/experimental/utils/mapper_utils.py
@@ -35,11 +35,6 @@ from celi_framework.experimental.utils.ada import get_openai_embedding_sync_time
 from celi_framework.utils.llms import quick_ask
 from celi_framework.utils.log import app_logger
 from celi_framework.utils.utils import load_json, get_section_context_as_text
-from celi_framework.experimental.utils.ada import get_openai_embedding_sync_timeouts
-from celi_framework.utils.llms import quick_ask
-from celi_framework.utils.log import app_logger
-from celi_framework.utils.token_counters import get_master_counter_instance
-from celi_framework.utils.utils import load_json, get_section_context_as_text
 
 TOKEN_LIMIT_PER_MINUTE = 120000
 

--- a/celi_framework/experimental/utils/mapper_utils.py
+++ b/celi_framework/experimental/utils/mapper_utils.py
@@ -23,17 +23,18 @@ import ast
 import json
 import os
 from collections import defaultdict, Counter
+
 import numpy as np
 import pandas as pd
 from sklearn.metrics.pairwise import cosine_similarity
-from celi_framework.experimental.utils.ada import get_openai_embedding_sync_timeouts
-from celi_framework.utils.llms import quick_ask
+
 from celi_framework.experimental.templates import (
     create_prompt_for_essential_section_analysis,
 )
-from celi_framework.utils.token_counters import get_master_counter_instance
-from celi_framework.utils.utils import load_json, get_section_context_as_text
+from celi_framework.experimental.utils.ada import get_openai_embedding_sync_timeouts
+from celi_framework.utils.llms import quick_ask
 from celi_framework.utils.log import app_logger
+from celi_framework.utils.utils import load_json, get_section_context_as_text
 
 TOKEN_LIMIT_PER_MINUTE = 120000
 
@@ -348,13 +349,10 @@ def source_material_getter(section_number):
             extra={"color": "blue"},
         )
 
-        token_counter = get_master_counter_instance()
-
         app_logger.info("Calling home to GPT", extra={"color": "yellow"})
 
         response_str = quick_ask(
             prompt,
-            token_counter=token_counter,
             json_output=True,
             timeout=None,
             model_name="gpt-4-turbo-preview",

--- a/celi_framework/main.py
+++ b/celi_framework/main.py
@@ -94,6 +94,7 @@ def parse_standard_args(args):
         primary_model_name=args.primary_model_name,
         model_url=args.model_api_url,
         max_tokens=args.max_tokens,
+        token_budget=args.token_budget,
     )
 
 
@@ -146,6 +147,16 @@ def setup_standard_args():
         help="CELI requires a job description to know what task to run.  This parameter specifies the Python class name"
         " for the class containing the job description.  It must have JobDescription as a base class.  Several "
         "example job descriptions are provided within the celi_framework.examples module.",
+    )
+    parser.add_argument(
+        "--token_budget",
+        type=int,
+        default=os.getenv(
+            "TOKEN_BUDGET",
+            0,
+        ),
+        help="Total budget in tokens for a singe CELI run, across all calls.  If set to 0, there is no budget.  This "
+        "only includes live calls, not cached calls.  If the budget is exceeded, the run will stop.",
     )
     bool_opt(
         parser,

--- a/celi_framework/main.py
+++ b/celi_framework/main.py
@@ -86,6 +86,9 @@ def parse_standard_args(args):
     if args.openai_api_key:
         os.environ["OPENAI_API_KEY"] = args.openai_api_key
 
+    if args.no_cache:
+        logger.warning("LLM Caching is turned off.")
+
     return CELIConfig(  # noqa: F821
         job_description=get_obj_by_name(args.job_description),
         tool_implementations=None,
@@ -153,7 +156,7 @@ def setup_standard_args():
         type=int,
         default=os.getenv(
             "TOKEN_BUDGET",
-            0,
+            10000000,
         ),
         help="Total budget in tokens for a singe CELI run, across all calls.  If set to 0, there is no budget.  This "
         "only includes live calls, not cached calls.  If the budget is exceeded, the run will stop.",

--- a/celi_framework/utils/llms.py
+++ b/celi_framework/utils/llms.py
@@ -38,10 +38,7 @@ from requests import HTTPError
 
 from celi_framework.utils.llm_cache import get_celi_llm_cache
 from celi_framework.utils.log import app_logger
-from celi_framework.utils.token_counters import (
-    token_counter_decorator_ask_split,
-    token_counter_decorator_quick_ask,
-)
+from celi_framework.utils.token_counters import TokenCounter
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +57,6 @@ class ToolDescription(BaseModel):
     parameters: Dict[str, Any]
 
 
-@token_counter_decorator_ask_split  # TODO - Not necessary to run outside of project
 async def ask_split(
     user_prompt: str | List[Tuple[str, str]],
     system_message,
@@ -75,6 +71,7 @@ async def ask_split(
     tool_descriptions: Optional[List[ToolDescription]] = None,
     model_url: Optional[str] = None,
     json_mode: bool = False,
+    token_counter: Optional[TokenCounter] = None,
 ):
     """
     Sends a prompt to the OpenAI API and returns the response, with retries on error.
@@ -90,6 +87,7 @@ async def ask_split(
                 app_logger.error(f"Attempt {err_cnt + 1}:", extra={"color": "red"})
             if model_url is None:
                 chat_completion = await cached_chat_completion(
+                    token_counter=token_counter,
                     base_url=model_url,
                     messages=[
                         {"role": "system", "content": system_message},
@@ -113,6 +111,7 @@ async def ask_split(
                 )
             else:
                 chat_completion = await cached_chat_completion(
+                    token_counter=token_counter,
                     base_url=model_url,
                     messages=[
                         {"role": "system", "content": system_message},
@@ -152,10 +151,8 @@ async def ask_split(
     raise last_error  # type: ignore
 
 
-@token_counter_decorator_quick_ask
 def quick_ask(
     prompt,
-    token_counter,
     model_name,
     max_tokens=None,
     temperature=None,
@@ -167,6 +164,7 @@ def quick_ask(
     timeout=90,
     time_increase=30,
     model_url: Optional[str] = None,
+    token_counter: Optional[TokenCounter] = None,
 ):
     """
     Simplified version of ask_split for quickly sending prompts to the OpenAI API, with error handling and retries.
@@ -184,11 +182,6 @@ def quick_ask(
     Returns:
         str: The content of the response message or error message after all retries.
     """
-    if token_counter is None:
-        app_logger.error(
-            f"global_token_counter inside quick_ask definition is {token_counter}",
-            extra={"color": "red"},
-        )
     err_cnt = 0
     last_error = None
 
@@ -211,6 +204,7 @@ def quick_ask(
 
             chat_completion = asyncio.run(
                 cached_chat_completion(
+                    token_counter=token_counter,
                     base_url=model_url,
                     messages=assemble_chat_messages(prompt),
                     model=model_name,
@@ -281,7 +275,11 @@ def assemble_chat_messages(prompt: str | List[Tuple[str, str] | Dict[str, str]])
         return [format_message(msg) for msg in prompt]
 
 
-async def cached_chat_completion(base_url: Optional[str], **kwargs) -> ChatCompletion:
+async def cached_chat_completion(
+    token_counter: Optional[TokenCounter] = None,
+    base_url: Optional[str] = None,
+    **kwargs,
+) -> ChatCompletion:
     cache = get_celi_llm_cache()
     if cache:
         url_dict = {} if base_url is None else {"base_url": base_url}
@@ -291,20 +289,40 @@ async def cached_chat_completion(base_url: Optional[str], **kwargs) -> ChatCompl
             app_logger.debug("Using cached LLM response")
             if isinstance(ret, str):
                 logger.info(ret)
-            return ChatCompletion.model_validate(ret["completion"])
+            result = ChatCompletion.model_validate(ret["completion"])
+            if token_counter:
+                token_counter.count_cached_tokens(
+                    kwargs.get("messages", ""),
+                    kwargs.get("tools", ""),
+                    result.choices[0].message.content,
+                )
+            return result
         else:
             app_logger.debug("Caching LLM response")
             result = await get_openai_client(
                 base_url=base_url,
             ).chat.completions.create(**kwargs)
+            if token_counter:
+                token_counter.count_request_tokens(
+                    kwargs.get("messages", ""), kwargs.get("tools", "")
+                )
             await cache.cache_llm_response(
                 response={"completion": result.dict()}, **cache_args
             )
+            if token_counter:
+                token_counter.count_response_tokens(result.choices[0].message.content)
             return result
     else:
-        return await get_openai_client(base_url=base_url).chat.completions.create(
+        if token_counter:
+            token_counter.count_request_tokens(
+                kwargs.get("messages", ""), kwargs.get("tools", "")
+            )
+        result = await get_openai_client(base_url=base_url).chat.completions.create(
             **kwargs
         )
+        if token_counter:
+            token_counter.count_response_tokens(result.choices[0].message.content)
+        return result
 
 
 class ContextLengthExceededException(Exception):

--- a/celi_framework/utils/token_counters.py
+++ b/celi_framework/utils/token_counters.py
@@ -8,15 +8,7 @@ Key Components:
         using the `tiktoken` library for encoding. It's designed for cases where accuracy is paramount.
     - `token_counter_est`: Provides a quick estimation of token count based on word count, using a heuristic approach.
         This function is useful for scenarios where performance is a consideration, and an exact token count is less critical.
-    - `TokenCounter`: A singleton class that tracks the number of tokens in requests and responses. It supports
-        multiple instances (e.g., 'master', 'monitor') for different monitoring purposes within the same application,
-        ensuring that only one instance of each type is created.
-    - `get_master_counter_instance` and `get_monitor_counter_instance`: Factory functions that return singleton instances
-        of the `TokenCounter` class for specific purposes ('master' and 'monitor', respectively), ensuring application-wide
-        consistency in token counting.
-    - `token_counter_decorator_ask_split` and `token_counter_decorator_quick_ask`: Decorators designed to wrap API call
-        functions, counting tokens in both the request and response phases. These are particularly useful for integrating
-        token counting into existing API interactions, providing a seamless way to monitor and manage token usage.
+    - `TokenCounter`: A class that tracks the number of tokens in requests and responses.
 
 Usage:
 This module is intended to be used in applications that require detailed monitoring and management of token usage,
@@ -24,29 +16,10 @@ especially when interfacing with language models. It provides both precise and e
 along with a mechanism to track token usage throughout the application lifecycle via the `TokenCounter` class and
 its singleton instances. The decorators offer a convenient way to add token counting to API calls without significant
 modification to existing code.
-
-Example::
-
-    from utils.token_counters import get_master_counter_instance, token_counter_decorator_quick_ask
-
-    # Retrieve the master token counter instance
-    master_counter = get_master_counter_instance()
-
-    # Example API call function
-    @api_call_function
-    def fetch_data(api_endpoint, data):
-        return "Simulated response"
-
-    # Wrap the API call function with token counting
-    fetch_data_decorated = token_counter_decorator_quick_ask(fetch_data)
-
-    # Use the decorated function as normal
-    response = fetch_data_decorated(api_endpoint="http://example.com/api", data={"query": "example"}, token_counter=master_counter)
-
-This module is a comprehensive solution for managing token usage, crucial for optimizing interactions with language models and other token-based APIs.
 """
 
-import functools
+from dataclasses import dataclass, field
+from typing import Callable
 
 from celi_framework.utils.log import app_logger
 
@@ -91,160 +64,28 @@ def token_counter_est(string: str) -> int:
     return estimated_tokens
 
 
-# utils/token_counter.py
-
-
+@dataclass
 class TokenCounter:
-    """Singleton class for counting tokens in requests and responses.
+    """Counts tokens in requests and responses and applies an optional budget."""
 
-    This class is designed as a singleton to ensure that only one instance of each counter type exists within the application.
-    It allows for tracking the number of tokens in requests and responses, supporting multiple counter types.
+    token_budget: int = 0
+    token_counter_fn: Callable[[str], int] = token_counter_est
 
-    Attributes:
-        counter_type (str): A label for the counter instance, defaulting to 'general'.
-        request_tokens (int): The total count of tokens in requests.
-        response_tokens (int): The total count of tokens in responses.
-    """
+    current_token_count: int = field(default=0, init=False)
+    cached_token_count: int = field(default=0, init=False)
 
-    _instances = {}  # Class level dictionary to hold instances
+    def count_request_tokens(self, *prompt_fields):
+        """Counts request tokens by converting all prompt_fields to strings and raises an exception if it exceeded the budget."""
+        self.current_token_count += sum(
+            self.token_counter_fn(str(_)) for _ in prompt_fields
+        )
+        if self.token_budget and self.current_token_count > self.token_budget:
+            raise ValueError("LLM Token budget exceeded")
 
-    def __new__(cls, counter_type="general"):
-        if counter_type not in cls._instances:
-            cls._instances[counter_type] = super(TokenCounter, cls).__new__(cls)
-            app_logger.info(
-                f"Initialized Global Token Counter: {counter_type}",
-                extra={"color": "dark_grey"},
-            )
-        return cls._instances[counter_type]
+    def count_response_tokens(self, response: str | None):
+        self.current_token_count += self.token_counter_fn(str(response))
 
-    def __init__(self, counter_type="general"):
-        self.counter_type = counter_type
-        self.request_tokens = 0
-        self.response_tokens = 0
-
-    def count_tokens(self, message, is_response=False):
-        try:
-            # logger.info(f"Trying to run count_tokens", extra={'color': 'gray'})
-            count = token_counter_og(message)
-            if is_response:
-                self.response_tokens += count
-            else:
-                self.request_tokens += count
-        except Exception as e:
-            app_logger.error(e)
-
-    def get_total_tokens(self):
-        return self.request_tokens, self.response_tokens
-
-
-def get_master_counter_instance():
-    """Retrieve or create the singleton instance of the TokenCounter for the master counter.
-
-    This function ensures that there is only one 'master' instance of the TokenCounter being used
-    throughout the application, following the Singleton design pattern.
-
-    Returns:
-        TokenCounter: The singleton instance of the master TokenCounter.
-    """
-    token_counter = TokenCounter(counter_type="master")
-    return token_counter
-
-
-def get_monitor_counter_instance():
-    """Retrieve or create the singleton instance of the TokenCounter for the monitor counter.
-
-    This function ensures that there is only one 'monitor' instance of the TokenCounter being used
-    throughout the application, adhering to the Singleton design pattern. This specific instance
-    can be used for monitoring purposes, separate from the master counter.
-
-    Returns:
-        TokenCounter: The singleton instance of the monitor TokenCounter.
-    """
-    token_counter = TokenCounter(counter_type="monitor")
-    return token_counter
-
-
-def token_counter_decorator_ask_split(api_call_function):
-    """Decorator to count tokens before and after an API call within an ask_split scenario.
-
-    This decorator wraps an API call function, counts the tokens in both the user prompt and the system message
-    before making the call, and counts the tokens in the response after the call. This is particularly useful
-    for operations that involve splitting user queries and system responses, ensuring accurate token tracking.
-
-    Args:
-        api_call_function (callable): The API call function to be decorated.
-
-    Returns:
-        callable: The wrapper function that enhances the original API call function with token counting.
-    """
-
-    @functools.wraps(api_call_function)
-    def wrapper(*args, **kwargs):
-        # Assume the token counter instance is passed as an argument
-        dec_token_counter = kwargs.get("token_counter")
-        if not dec_token_counter:
-            return api_call_function(
-                *args, **kwargs
-            )  # Proceed with the call without token counting
-
-        user_prompt = kwargs.get("user_prompt") or args[1]
-        system_message = kwargs.get("system_message", "")
-
-        # Count tokens in the request
-        dec_token_counter.count_tokens(system_message)
-        dec_token_counter.count_tokens(user_prompt)
-
-        # Make the API call
-        # logger.info(f"Token_decorator - Trying to run api_call", extra={'color': 'gray'})
-        response = api_call_function(*args, **kwargs)
-        # logger.info(f"Token_decorator - Response received api_call", extra={'color': 'gray'})
-
-        # For ask_split the response is choices[0] dict, and not the message, so let's handle that
-        if type(response) != str and response is not None:
-            response_txt = response.message.content
-        else:
-            response_txt = response
-
-        # Count tokens in the response
-        if response_txt:
-            dec_token_counter.count_tokens(response_txt, is_response=True)
-
-        # logger.info(f"Token_decorator - Response text which was counted: {response_txt}", extra={'color': 'gray'})
-        # logger.info(f"Token_decorator - Response received and to be returned: {response}", extra={'color': 'gray'})
-        return response
-
-    return wrapper
-
-
-def token_counter_decorator_quick_ask(api_call_function):
-    """Decorator to count tokens before and after making a quick API call.
-
-    This decorator is designed to quickly count the tokens in the prompt before making an API call and
-    in the response after the call. It's streamlined for scenarios where prompt and response token counting
-    is essential but must be done with minimal overhead.
-
-    Args:
-        api_call_function (callable): The API call function to be decorated.
-
-    Returns:
-        callable: The wrapper function that adds token counting functionality to the original API call function.
-    """
-
-    @functools.wraps(api_call_function)
-    def wrapper(*args, **kwargs):
-        token_counter = kwargs.get("token_counter")
-        if not token_counter:
-            return api_call_function(*args, **kwargs)  # Proceed without token counting
-
-        prompt = kwargs.get("prompt") or args[0]
-
-        token_counter.count_tokens(prompt)
-
-        response = api_call_function(*args, **kwargs)
-
-        if isinstance(response, str):
-            token_counter.count_tokens(response, is_response=True)
-
-        return response
-
-    return wrapper
+    def count_cached_tokens(self, *prompt_fields):
+        self.cached_token_count += sum(
+            self.token_counter_fn(str(_)) for _ in prompt_fields
+        )

--- a/docs/running_celi.md
+++ b/docs/running_celi.md
@@ -44,6 +44,10 @@ options:
                         class name for the class containing the job description. It must have JobDescription as a base
                         class. Several example job descriptions are provided within the celi_framework.examples
                         module.
+  --token_budget TOKEN_BUDGET
+                        Total budget in tokens for a singe CELI run, across all calls. If set to 0, there is no
+                        budget. This only includes live calls, not cached calls. If the budget is exceeded, the run
+                        will stop.
   --simulate-live       Set to true to add a delay to the LLM cache. This simulates what a live run would look like
                         even when cached LLM results are used
   --no-cache            Set to True to turn off LLM caching

--- a/tests/utils/test_llms.py
+++ b/tests/utils/test_llms.py
@@ -23,8 +23,6 @@ async def test_ask_split():
 
 
 def test_quick_ask():
-    ret = quick_ask(
-        "Hello", token_counter=None, model_name=os.getenv("PRIMARY_LLM", None)
-    )
+    ret = quick_ask("Hello", model_name=os.getenv("PRIMARY_LLM", None))
     assert type(ret) == str
     logger.info(f"LLM returned: {ret}")


### PR DESCRIPTION
As described in the docs:

  --token_budget TOKEN_BUDGET
                        Total budget in tokens for a singe CELI run, across all calls. If set to 0, there is no
                        budget. This only includes live calls, not cached calls. If the budget is exceeded, the run
                        will stop.
 