### PR TITLE
Added exponential backoff to handle OpenAI rate limiting.

### DIFF
--- a/celi_framework/utils/llms.py
+++ b/celi_framework/utils/llms.py
@@ -342,7 +342,7 @@ async def create_chat_completion_with_retry(base_url, **kwargs):
             retry_attempts += 1
             if retry_attempts > max_retries:
                 raise e
-            sleep_time = 60 + backoff_factor**retry_attempts + random.uniform(0, 1)
+            sleep_time = 60 + 20*random.uniform(0, 1)*backoff_factor**retry_attempts
             logger.warning(
                 f"Rate limit exceeded. Retrying in {sleep_time:.2f} seconds..."
             )

--- a/celi_framework/utils/llms.py
+++ b/celi_framework/utils/llms.py
@@ -342,7 +342,7 @@ async def create_chat_completion_with_retry(base_url, **kwargs):
             retry_attempts += 1
             if retry_attempts > max_retries:
                 raise e
-            sleep_time = 60 + 20*random.uniform(0, 1)*backoff_factor**retry_attempts
+            sleep_time = 60 + 20 * random.uniform(0, 1) * backoff_factor**retry_attempts
             logger.warning(
                 f"Rate limit exceeded. Retrying in {sleep_time:.2f} seconds..."
             )


### PR DESCRIPTION
Rate limits reset once a minute, so when when we hit a limit, we wait a minute plus a random extra amount of time (from 0 to 40 seconds for the first back, up to 20 minutes for the 5th try).