### PR TITLE
Removed temperature argument from the Anthropic model call if it is equal to none

### DIFF
--- a/celi_framework/utils/anthropic_client.py
+++ b/celi_framework/utils/anthropic_client.py
@@ -40,7 +40,7 @@ def _convert_openai_to_anthropic_input(**kwargs):
     remaining_kwargs = {
         k: v
         for k, v in kwargs.items()
-        if k not in ["response_format", "seed", "tools", "tool_choice"]
+        if k not in ["response_format", "seed", "tools", "tool_choice"] and (k != "temperature" or v is not None)
     }
 
     def fix_tool(t):


### PR DESCRIPTION
Including a null value for temperature in the Bedrock Anthropic API call returns: "Error code: 400 - {'message': 'Malformed input request: #: subject must not be valid against schema {"required":["messages"]}#/temperature: expected type: Number, found: Null, please reformat your input and try again.'}"