### PR TITLE
Many fixes related to loop detection and the builtin review:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .DS_Store
 .vscode
 .local_notebooks
+*.iml
 dist/
 target/
 output/

--- a/celi_framework/main.py
+++ b/celi_framework/main.py
@@ -106,6 +106,7 @@ def parse_standard_args(args):
         max_tokens=args.max_tokens,
         token_budget=args.token_budget,
         sequential=args.sequential,
+        force_tool_every_n=args.force_tool_every_n,
     )
 
 


### PR DESCRIPTION
In summary, these functions fix a lot of cases where the builtin review wasn't behaving correctly.  This was especially a problem with very lon gsystem messages, which would either get summarized, or would go over the output token limit for the JSON response from the LLM.  

Many fixes related to loop detection and the builtin review:
* Change the seed when we do a new iteration
* If we get a blank response from the LLM add in a user message to prompt a better result next time.
* Updated the builtin review prompt to stress that the user and system messages must be preserved.  This avoids the LLM summarizing those.
* Added more explicit in context examples to the builtin review
* In the case where invalid JSON is returned from the builtin review, rerun it without asking the LLM to change the system message.
* Make updating the system message optional even in the first pass review.
* Fixed a bug where "force_tool_use_every_n" command line argument was ignored